### PR TITLE
Add forgot password screen with email confirmation

### DIFF
--- a/lib/presentation/forgot_password_screen/forgot_password_screen.dart
+++ b/lib/presentation/forgot_password_screen/forgot_password_screen.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+
+import '../../core/app_export.dart';
+import '../../widgets/custom_button.dart';
+import '../../widgets/custom_image_view.dart';
+import '../../widgets/custom_text_field.dart';
+
+class ForgotPasswordScreen extends StatelessWidget {
+  ForgotPasswordScreen({super.key});
+
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController confirmEmailController = TextEditingController();
+
+  void _handleRecover(BuildContext context) {
+    String email = emailController.text.trim();
+    String confirmEmail = confirmEmailController.text.trim();
+
+    if (email.isEmpty || confirmEmail.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Por favor, preencha ambos os e-mails.'),
+          backgroundColor: appTheme.redCustom,
+        ),
+      );
+      return;
+    }
+
+    if (!email.contains('@') || !email.contains('.')) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Por favor, insira um e-mail válido.'),
+          backgroundColor: appTheme.redCustom,
+        ),
+      );
+      return;
+    }
+
+    if (email != confirmEmail) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Os e-mails devem ser iguais.'),
+          backgroundColor: appTheme.redCustom,
+        ),
+      );
+      return;
+    }
+
+    final navigator = Navigator.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('E-mail de recuperação enviado!'),
+        backgroundColor: appTheme.greenCustom,
+      ),
+    );
+
+    Future.delayed(const Duration(seconds: 2), () {
+      navigator.pop();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: appTheme.colorFFF1F1,
+      body: Stack(
+        children: [
+          Positioned(
+            top: 11.h,
+            left: 0,
+            child: CustomImageView(
+              imagePath: ImageConstant.imgImage5,
+              height: 885.h,
+              width: 428.h,
+              fit: BoxFit.cover,
+            ),
+          ),
+          SafeArea(
+            child: Center(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.symmetric(horizontal: 16.h),
+                child: Container(
+                  width: double.infinity,
+                  constraints: BoxConstraints(maxWidth: 400.h),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Container(
+                        margin: EdgeInsets.only(bottom: 32.h),
+                        child: Text(
+                          'PetAdote',
+                          style: TextStyleHelper
+                              .instance.display50RegularLeckerliOne
+                              .copyWith(height: 1.36),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                      Column(
+                        children: [
+                          CustomTextField(
+                            placeholder: 'E-mail',
+                            controller: emailController,
+                            keyboardType: TextInputType.emailAddress,
+                            textInputAction: TextInputAction.next,
+                          ),
+                          SizedBox(height: 24.h),
+                          CustomTextField(
+                            placeholder: 'Confirmar e-mail',
+                            controller: confirmEmailController,
+                            keyboardType: TextInputType.emailAddress,
+                            textInputAction: TextInputAction.done,
+                            onSubmitted: (_) => _handleRecover(context),
+                          ),
+                          SizedBox(height: 32.h),
+                          CustomButton(
+                            text: 'Recuperar',
+                            onPressed: () => _handleRecover(context),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/login_screen/login_screen.dart
+++ b/lib/presentation/login_screen/login_screen.dart
@@ -37,14 +37,12 @@ class LoginScreenState extends State<LoginScreen> {
   void _handleLogin() {
     if (_emailController.text.isNotEmpty &&
         _passwordController.text.isNotEmpty) {
-      
       debugPrint('Login attempt: ${_emailController.text}');
     }
   }
 
   void _handleForgotPassword() {
-    
-    debugPrint('Forgot password clicked');
+    Navigator.of(context).pushNamed(AppRoutes.forgotPasswordScreen);
   }
 
   void _handleRegister() {
@@ -56,9 +54,7 @@ class LoginScreenState extends State<LoginScreen> {
     return Scaffold(
         backgroundColor: appTheme.colorFF9FE5,
         body: Stack(children: [
-          
           Positioned(
-
               top: 11.h,
               left: 0,
               child: Opacity(
@@ -68,30 +64,24 @@ class LoginScreenState extends State<LoginScreen> {
                       height: 885.h,
                       width: 428.h,
                       fit: BoxFit.cover))),
-
-          
-            Positioned(
-                top: 118.h,
-                left: 30.h,
-                child: SizedBox(
-                    height: 669.h,
-                    width: 372.h,
-                    child: Column(children: [
-
-                      Padding(
-                          padding: EdgeInsets.only(bottom: 166.h),
-                          child: SizedBox(
-                              height: 84.h,
-                              width: 222.h,
-                              child: Center(
-                                  child: Text('PetAdote',
-                                      style: TextStyleHelper
-                                          .instance.display55LeckerliOne
-                                          .copyWith(height: 1.35))))),
-
-                    
+          Positioned(
+              top: 118.h,
+              left: 30.h,
+              child: SizedBox(
+                  height: 669.h,
+                  width: 372.h,
+                  child: Column(children: [
+                    Padding(
+                        padding: EdgeInsets.only(bottom: 166.h),
+                        child: SizedBox(
+                            height: 84.h,
+                            width: 222.h,
+                            child: Center(
+                                child: Text('PetAdote',
+                                    style: TextStyleHelper
+                                        .instance.display55LeckerliOne
+                                        .copyWith(height: 1.35))))),
                     Column(children: [
-                      
                       CustomTextField(
                           placeholder: 'E-mail',
                           controller: _emailController,
@@ -105,10 +95,7 @@ class LoginScreenState extends State<LoginScreen> {
                           fontSize: 20.fSize,
                           onSubmitted: (_) =>
                               _passwordFocusNode.requestFocus()),
-
                       SizedBox(height: 32.h),
-
-                      
                       SizedBox(
                           height: 45.h,
                           width: 372.h,
@@ -133,28 +120,23 @@ class LoginScreenState extends State<LoginScreen> {
                                     top: 12.h,
                                     bottom: 12.h),
                                 onSubmitted: (_) => _handleLogin()),
-
-                            
-                              Positioned(
-                                  right: 12.h,
-                                  top: 0,
-                                  bottom: 0,
-                                  child: GestureDetector(
-                                      onTap: _togglePasswordVisibility,
-                                      child: SizedBox(
-                                          width: 24.h,
-                                          height: 24.h,
-                                          child: Center(
-                                              child: CustomImageView(
-                                                  imagePath: ImageConstant.img2,
-                                                  width: 24.h,
-                                                  height: 24.h,
-                                                  color: appTheme.grey600))))),
+                            Positioned(
+                                right: 12.h,
+                                top: 0,
+                                bottom: 0,
+                                child: GestureDetector(
+                                    onTap: _togglePasswordVisibility,
+                                    child: SizedBox(
+                                        width: 24.h,
+                                        height: 24.h,
+                                        child: Center(
+                                            child: CustomImageView(
+                                                imagePath: ImageConstant.img2,
+                                                width: 24.h,
+                                                height: 24.h,
+                                                color: appTheme.grey600))))),
                           ])),
-
                       SizedBox(height: 43.h),
-
-                      
                       CustomButton(
                           text: 'Entrar',
                           onPressed: _handleLogin,
@@ -167,10 +149,7 @@ class LoginScreenState extends State<LoginScreen> {
                           borderRadius: 0,
                           elevation: 4.h,
                           shadowColor: appTheme.blackCustom),
-
                       SizedBox(height: 14.h),
-
-                      
                       GestureDetector(
                           onTap: _handleForgotPassword,
                           child: Text('Esqueci a senha',
@@ -178,10 +157,7 @@ class LoginScreenState extends State<LoginScreen> {
                                   .copyWith(
                                       height: 1.27,
                                       decoration: TextDecoration.underline))),
-
                       SizedBox(height: 138.h),
-
-                      
                       CustomButton(
                           text: 'CADASTRE-SE',
                           onPressed: _handleRegister,

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import '../presentation/registration_screen/registration_screen.dart';
 import '../presentation/login_screen/login_screen.dart';
+import '../presentation/forgot_password_screen/forgot_password_screen.dart';
 
 import '../presentation/app_navigation_screen/app_navigation_screen.dart';
 
 class AppRoutes {
   static const String registrationScreen = '/registration_screen';
   static const String loginScreen = '/login_screen';
+  static const String forgotPasswordScreen = '/forgot_password_screen';
 
   static const String appNavigationScreen = '/app_navigation_screen';
   static const String initialRoute = '/';
@@ -14,6 +16,7 @@ class AppRoutes {
   static Map<String, WidgetBuilder> get routes => {
         registrationScreen: (context) => RegistrationScreen(),
         loginScreen: (context) => LoginScreen(),
+        forgotPasswordScreen: (context) => ForgotPasswordScreen(),
         appNavigationScreen: (context) => AppNavigationScreen(),
         initialRoute: (context) => AppNavigationScreen()
       };


### PR DESCRIPTION
## Summary
- add forgot password screen to recover password with email confirmation and validation
- hook login screen "Esqueci a senha" link to the new screen
- register new route for password recovery screen

## Testing
- `flutter analyze` *(warning: include file 'package:flutter_lints/flutter.yaml' can't be found)*
- `flutter test` *(failed: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_68a519b66e98833392bd15f84021c1c8