### PR TITLE
Add home screen with menu and profile icons

### DIFF
--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../core/app_export.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: appTheme.whiteCustom,
+          elevation: 0,
+          leading: IconButton(
+            icon: Icon(Icons.menu, color: appTheme.blackCustom),
+            onPressed: () {},
+          ),
+          actions: [
+            IconButton(
+              icon: Icon(Icons.person, color: appTheme.blackCustom),
+              onPressed: () {},
+            )
+          ],
+        ),
+        body: Center(
+          child: Text(
+            'hello world',
+            style: TextStyleHelper.instance.title20RegularRoboto,
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -4,11 +4,14 @@ import '../presentation/login_screen/login_screen.dart';
 import '../presentation/forgot_password_screen/forgot_password_screen.dart';
 
 import '../presentation/app_navigation_screen/app_navigation_screen.dart';
+import '../presentation/home_screen/home_screen.dart';
 
 class AppRoutes {
   static const String registrationScreen = '/registration_screen';
   static const String loginScreen = '/login_screen';
   static const String forgotPasswordScreen = '/forgot_password_screen';
+
+  static const String homeScreen = '/home_screen';
 
   static const String appNavigationScreen = '/app_navigation_screen';
   static const String initialRoute = '/';
@@ -17,7 +20,8 @@ class AppRoutes {
         registrationScreen: (context) => RegistrationScreen(),
         loginScreen: (context) => LoginScreen(),
         forgotPasswordScreen: (context) => ForgotPasswordScreen(),
+        homeScreen: (context) => HomeScreen(),
         appNavigationScreen: (context) => AppNavigationScreen(),
-        initialRoute: (context) => AppNavigationScreen()
+        initialRoute: (context) => HomeScreen()
       };
 }


### PR DESCRIPTION
## Summary
- add a simple HomeScreen with hamburger and profile icons and centered greeting
- register HomeScreen in routes and make it the app's initial route

## Testing
- ⚠️ `flutter analyze` *(command not found)*
- ⚠️ `dart analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a524667ad483338720d5c4ce752da9